### PR TITLE
Check if services are enabled before taking actions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: 'BSD-3-Clause'
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
 
   platforms:
   - name: SUSE

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,25 @@
 ---
 # disable_cloud-init_services/tasks/main.yml
+- name: 'Populate service facts'
+  service_facts:
 
 - name: 'Disable and stop all cloud-init services'
   service:
-    name: "{{ item }}"
+    name: "{{ service }}"
     state: 'stopped'
     enabled: 'false'
-  with_items: "{{ cloud_init_services }}"
-  when: 'not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")'
+  loop: "{{ cloud_init_services }}"
+  loop_control:
+    loop_var: service
+  when:
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")
+    - ansible_facts.services[service] is defined
+    - ansible_facts.services[service].status == 'enabled'
+
+- name: 'check if /etc/cloud/ exists'
+  stat:
+    path: /etc/cloud/
+  register: etc_cloud_folder
 
 - name: 'Generate /etc/cloud/cloud-init.disabled'
   copy:
@@ -16,3 +28,4 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  when: etc_cloud_folder.stat.exists


### PR DESCRIPTION
This role got me some trouble when i accidentally ran it against an Debian Host which had only the cloud-init service, but not cloud-final service and one host which didn't have cloud-init at all.

Now the role checks if the service is found and enabled before trying to stop and disable it. If no service is found the task is simply empty and works as designed. Can now also be run against host which don't have cloud-init at all.